### PR TITLE
Add initial DB schema and scoring logic

### DIFF
--- a/lib/score.ts
+++ b/lib/score.ts
@@ -1,0 +1,37 @@
+export interface Prediction {
+  homeScore: number
+  awayScore: number
+}
+
+export interface Result {
+  homeScore: number
+  awayScore: number
+}
+
+/**
+ * Calculate points earned for a prediction.
+ *
+ * - 3 points for an exact score.
+ * - 1 point for correctly predicting the outcome (win/lose/draw) but not the
+ *   exact score.
+ */
+export function calculateScore(
+  prediction: Prediction,
+  result: Result
+): number {
+  if (
+    prediction.homeScore === result.homeScore &&
+    prediction.awayScore === result.awayScore
+  ) {
+    return 3
+  }
+
+  const predictedDiff = prediction.homeScore - prediction.awayScore
+  const resultDiff = result.homeScore - result.awayScore
+
+  // Normalize to -1, 0, 1 for away win, draw or home win
+  const predictedOutcome = Math.sign(predictedDiff)
+  const resultOutcome = Math.sign(resultDiff)
+
+  return predictedOutcome === resultOutcome ? 1 : 0
+}

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,45 @@
+-- Database schema for prode-pad
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Jugadores table (players)
+CREATE TABLE IF NOT EXISTS jugadores (
+  id SERIAL PRIMARY KEY,
+  nombre TEXT NOT NULL,
+  user_id INTEGER REFERENCES users(id),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Ligas table (leagues)
+CREATE TABLE IF NOT EXISTS ligas (
+  id SERIAL PRIMARY KEY,
+  nombre TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Matches table with estado field
+CREATE TABLE IF NOT EXISTS matches (
+  id SERIAL PRIMARY KEY,
+  liga_id INTEGER REFERENCES ligas(id),
+  home_team TEXT NOT NULL,
+  away_team TEXT NOT NULL,
+  home_score INTEGER,
+  away_score INTEGER,
+  estado TEXT NOT NULL DEFAULT 'scheduled',
+  played_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Predictions table
+CREATE TABLE IF NOT EXISTS predictions (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  match_id INTEGER REFERENCES matches(id),
+  home_score INTEGER NOT NULL,
+  away_score INTEGER NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- set up database schema with tables for users, jugadores, ligas, matches and predictions
- implement match prediction scoring helper

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648d379c00832b944111b4ffa4da53